### PR TITLE
IPipeValidation Interface

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       image: openknowledge/ckan-dev:${{ matrix.ckan-version }}
     services:
       solr:
-        image: ckan/ckan-solr-dev:${{ matrix.ckan-version }}
+        image: ckan/ckan-solr:${{ matrix.ckan-version }}
       postgres:
         image: ckan/ckan-postgres-dev:${{ matrix.ckan-version }}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.9'
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax

--- a/README.md
+++ b/README.md
@@ -154,13 +154,13 @@ hosted in CKAN itself or elsewhere. Whenever a resource of the appropriate
 format is created or updated, the extension will validate the data against a
 collection of checks. This validation is powered by
 [Frictionless Framework](https://github.com/frictionlessdata/framework), a very
-powerful data validation library developed by the [Open Knowledge Foundation](https://okfn.org) 
+powerful data validation library developed by the [Open Knowledge Foundation](https://okfn.org)
 as part of the [Frictionless Data](https://frictionlessdata.io) project.
 Frictionless Framework provides an extensive suite of [checks](https://framework.frictionlessdata.io/docs/checks/baseline.html)
 that cover common issues with tabular data files.
 
 These checks include structural problems like missing headers or values, blank
-rows, etc., but also can validate the data contents themselves (see 
+rows, etc., but also can validate the data contents themselves (see
 [Data Schemas](#data-schemas)) or even run [custom checks](https://framework.frictionlessdata.io/docs/guides/validating-data.html#custom-checks).
 
 The result of this validation is a JSON report. This report contains all the
@@ -427,7 +427,7 @@ to get up and running just by adding the following fields to the
 
 Here's more detail on the fields added:
 
-* `schema`: This can be a [Table Schema](http://frictionlessdata.io/specs/table-schema/) 
+* `schema`: This can be a [Table Schema](http://frictionlessdata.io/specs/table-schema/)
 JSON object or an URL pointing to one. In the UI form you can upload a JSON file, link to one
 providing a URL or enter it directly. If uploaded, the file contents will be
 read and stored in the `schema` field. In all three cases the contents will be
@@ -492,6 +492,21 @@ class IDataValidation(Interface):
 
         '''
         return True
+```
+
+The plugin also provides the `IPipeValidation` interface so other plugins can receive the dictized validation reports in a Data Pipeline way. This would allow plugins to perform actions once a validation job is finished.
+
+Example:
+```
+import ckan.plugins as plugins
+from ckanext.validation.interfaces import IPipeValidation
+
+class MyPlugin(plugins.SingletonPlugin):
+  plugins.implements(IPipeValidation)
+
+  def receive_validation_report(self, validation_report):
+    if validation_report.get('status') == 'success':
+      # Do something when the resource successfully passes validation
 ```
 
 ## Action functions

--- a/ckanext/validation/interfaces.py
+++ b/ckanext/validation/interfaces.py
@@ -39,3 +39,21 @@ class IDataValidation(Interface):
 
         '''
         return True
+
+
+class IPipeValidation(Interface):
+    """
+    Process data in a Data Pipeline.
+
+    Inherit this to subscribe to events in the Data Pipeline and be able to
+    broadcast the results for others to process next. In this way, a number of
+    IPipes can be linked up in sequence to build up a data processing pipeline.
+
+    When a resource is validated, it broadcasts its validation_report,
+    perhaps triggering a process which transforms the data to another format,
+    or loads it into a datastore. These processes can in turn put the resulting
+    validation reports into the pipeline
+    """
+
+    def receive_validation_report(self, validation_report):
+        pass

--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -15,7 +15,11 @@ import ckan.lib.uploader as uploader
 import ckantoolkit as t
 
 from ckanext.validation.model import Validation
-from ckanext.validation.utils import get_update_mode_from_config
+from ckanext.validation.utils import (
+    get_update_mode_from_config,
+    send_validation_report,
+    validation_dictize,
+)
 
 
 log = logging.getLogger(__name__)
@@ -132,6 +136,7 @@ def run_validation_job(resource):
         '_validation_performed': True
     }
     t.get_action('resource_patch')(patch_context, data_dict)
+    send_validation_report(validation_dictize(validation))
 
 
 

--- a/ckanext/validation/logic.py
+++ b/ckanext/validation/logic.py
@@ -19,6 +19,7 @@ from ckanext.validation.utils import (
     get_create_mode_from_config,
     get_update_mode_from_config,
     delete_local_uploaded_file,
+    validation_dictize,
 )
 
 
@@ -172,7 +173,7 @@ def resource_validation_show(context, data_dict):
         raise t.ObjectNotFound(
             'No validation report exists for this resource')
 
-    return _validation_dictize(validation)
+    return validation_dictize(validation)
 
 
 def resource_validation_delete(context, data_dict):
@@ -402,22 +403,6 @@ def _add_default_formats(search_data_dict):
     filter_formats_query = ['+res_format:"{0}"'.format(_format)
                             for _format in filter_formats]
     search_data_dict['fq_list'].append(' OR '.join(filter_formats_query))
-
-
-def _validation_dictize(validation):
-    out = {
-        'id': validation.id,
-        'resource_id': validation.resource_id,
-        'status': validation.status,
-        'report': validation.report,
-        'error': validation.error,
-    }
-    out['created'] = (
-        validation.created.isoformat() if validation.created else None)
-    out['finished'] = (
-        validation.finished.isoformat() if validation.finished else None)
-
-    return out
 
 
 @t.chained_action

--- a/ckanext/validation/tests/test_logic.py
+++ b/ckanext/validation/tests/test_logic.py
@@ -347,8 +347,9 @@ class TestAuth(object):
         user = factories.User()
         org = factories.Organization()
         dataset = factories.Dataset(
-            owner_org=org["id"], resources=[factories.Resource()]
+            owner_org=org["id"]
         )
+        resource = factories.Resource(package_id=dataset["id"])
 
         context = {"user": user["name"], "model": model}
 
@@ -357,7 +358,7 @@ class TestAuth(object):
             call_auth,
             "resource_validation_run",
             context=context,
-            resource_id=dataset["resources"][0]["id"],
+            resource_id=resource["id"],
         )
 
     def test_run_auth_user(self):
@@ -367,8 +368,9 @@ class TestAuth(object):
             users=[{"name": user["name"], "capacity": "editor"}]
         )
         dataset = factories.Dataset(
-            owner_org=org["id"], resources=[factories.Resource()]
+            owner_org=org["id"]
         )
+        resource = factories.Resource(package_id=dataset["id"])
 
         context = {"user": user["name"], "model": model}
 
@@ -376,7 +378,7 @@ class TestAuth(object):
             call_auth(
                 "resource_validation_run",
                 context=context,
-                resource_id=dataset["resources"][0]["id"],
+                resource_id=resource["id"],
             )
             is True
         )
@@ -416,8 +418,9 @@ class TestAuth(object):
         user = factories.User()
         org = factories.Organization()
         dataset = factories.Dataset(
-            owner_org=org["id"], resources=[factories.Resource()]
+            owner_org=org["id"]
         )
+        resource = factories.Resource(package_id=dataset["id"])
 
         context = {"user": user["name"], "model": model}
 
@@ -426,7 +429,7 @@ class TestAuth(object):
             call_auth,
             "resource_validation_delete",
             context=context,
-            resource_id=dataset["resources"][0]["id"],
+            resource_id=resource["id"],
         )
 
     def test_delete_auth_user(self):
@@ -436,8 +439,9 @@ class TestAuth(object):
             users=[{"name": user["name"], "capacity": "editor"}]
         )
         dataset = factories.Dataset(
-            owner_org=org["id"], resources=[factories.Resource()]
+            owner_org=org["id"]
         )
+        resource = factories.Resource(package_id=dataset["id"])
 
         context = {"user": user["name"], "model": model}
 
@@ -445,7 +449,7 @@ class TestAuth(object):
             call_auth(
                 "resource_validation_delete",
                 context=context,
-                resource_id=dataset["resources"][0]["id"],
+                resource_id=resource["id"],
             )
             is True
         )
@@ -468,8 +472,9 @@ class TestAuth(object):
         user = factories.User()
         org = factories.Organization()
         dataset = factories.Dataset(
-            owner_org=org["id"], resources=[factories.Resource()], private=False
+            owner_org=org["id"], private=False
         )
+        resource = factories.Resource(package_id=dataset["id"])
 
         context = {"user": user["name"], "model": model}
 
@@ -477,7 +482,7 @@ class TestAuth(object):
             call_auth(
                 "resource_validation_show",
                 context=context,
-                resource_id=dataset["resources"][0]["id"],
+                resource_id=resource["id"],
             )
             is True
         )
@@ -487,8 +492,9 @@ class TestAuth(object):
         user = factories.User()
         org = factories.Organization()
         dataset = factories.Dataset(
-            owner_org=org["id"], resources=[factories.Resource()], private=True
+            owner_org=org["id"], private=True
         )
+        resource = factories.Resource(package_id=dataset["id"])
 
         context = {"user": user["name"], "model": model}
 
@@ -497,7 +503,7 @@ class TestAuth(object):
             call_auth,
             "resource_validation_run",
             context=context,
-            resource_id=dataset["resources"][0]["id"],
+            resource_id=resource["id"],
         )
 
 


### PR DESCRIPTION
feat(dev): IPipeValidation interface;

- Created new `IPipeValidation` interface which sends dictized validation reports to other plugins.

Based implementation off of the Archiver plugin's `IPipe` https://github.com/ckan/ckanext-archiver/blob/master/ckanext/archiver/interfaces.py#L9

This would be very useful to plugins like `Xloader` and `Datapusher` to check a resource's validation and continue any processes to get the data into the DataStore.